### PR TITLE
Allow configuring guest options in CLI

### DIFF
--- a/filesender/api.py
+++ b/filesender/api.py
@@ -185,6 +185,7 @@ class FileSenderClient:
         self,
         body: request.Guest
     ) -> response.Guest:
+        """Sends a voucher to a guest to invite them to send files"""
         return self.sign_send(Request(
             "POST",
             f"{self.base_url}/guest",

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -65,12 +65,12 @@ class FileSenderClient:
         base_url: str,
         chunk_size: Optional[int] = None,
         auth: Auth = Auth(),
-        session: requests.Session = requests.Session(),
+        session: Optional[requests.Session] = None,
         threads: int = 1
     ):
         self.base_url = base_url
         self.auth = auth
-        self.session = session
+        self.session = session or requests.Session()
         self.executor = ThreadPoolExecutor(max_workers=threads)
         
         info = self.get_server_info()

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Set
 from typing_extensions import Annotated
 from bs4 import BeautifulSoup
-
 import requests
 from filesender.api import FileSenderClient
 from typer import Typer, Option, Argument, Context
@@ -36,6 +35,15 @@ def invite(
     recipient: Annotated[str, Argument(help="The email address of the person to invite")],
     context: Context,
     verbose: Annotated[bool, Argument(help="Enable more detailed outputs")] = False,
+    # Although these parameters are exact duplicates of those in GuestOptions,
+    # typer doesn't support re-using argument lists: https://github.com/tiangolo/typer/discussions/665
+    one_time: Annotated[bool, Option(help="If true, this voucher is only valid for one use, otherwise it can be re-used.")] = True,
+    only_to_me: Annotated[bool, Option(help="If true, this voucher can only be used to send files to you, the person who created this voucher. Otherwise they can send files to any email address.")] = True,
+    email_upload_started: Annotated[bool, Option(help="If true, an email will be sent to you, when an upload to this voucher starts.")] = False,
+    email_page_access: Annotated[bool, Option(help="If true, an email will be sent to you when the guest recipient accesses the upload page.")] = False,
+    email_guest_created: Annotated[bool, Option(help="If true, send an email to the guest user who is being invited to upload.")] = True,
+    email_receipt: Annotated[bool, Option(help="If true, send you an email when the guest account is created.")] = True,
+    email_guest_expired: Annotated[bool, Option(help="If true, send you an email when the voucher expires.")] = False,
     delay: Delay = 0
 ):
     """
@@ -54,7 +62,13 @@ def invite(
         "recipient": recipient,
         "options": {
             "guest": {
-                "can_only_send_to_me": True,
+                "valid_only_one_time": one_time,
+                "can_only_send_to_me": only_to_me,
+                "email_upload_started": email_upload_started,
+                "email_upload_page_access": email_page_access,
+                "email_guest_created": email_guest_created,
+                "email_guest_created_receipt": email_receipt,
+                "email_guest_expired": email_guest_expired
             }
         }
     })

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -61,15 +61,13 @@ def invite(
         "from": username,
         "recipient": recipient,
         "options": {
-            "guest": {
-                "valid_only_one_time": one_time,
-                "can_only_send_to_me": only_to_me,
-                "email_upload_started": email_upload_started,
-                "email_upload_page_access": email_page_access,
-                "email_guest_created": email_guest_created,
-                "email_guest_created_receipt": email_receipt,
-                "email_guest_expired": email_guest_expired
-            }
+            "valid_only_one_time": one_time,
+            "can_only_send_to_me": only_to_me,
+            "email_upload_started": email_upload_started,
+            "email_upload_page_access": email_page_access,
+            "email_guest_created": email_guest_created,
+            "email_guest_created_receipt": email_receipt,
+            "email_guest_expired": email_guest_expired
         }
     })
     if verbose:

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -34,7 +34,7 @@ def invite(
     apikey: Annotated[str, Option(help="Your API token. This is the token of the person doing the inviting, not the person being invited.")],
     recipient: Annotated[str, Argument(help="The email address of the person to invite")],
     context: Context,
-    verbose: Annotated[bool, Argument(help="Enable more detailed outputs")] = False,
+    verbose: Verbose,
     # Although these parameters are exact duplicates of those in GuestOptions,
     # typer doesn't support re-using argument lists: https://github.com/tiangolo/typer/discussions/665
     one_time: Annotated[bool, Option(help="If true, this voucher is only valid for one use, otherwise it can be re-used.")] = True,
@@ -61,13 +61,18 @@ def invite(
         "from": username,
         "recipient": recipient,
         "options": {
-            "valid_only_one_time": one_time,
-            "can_only_send_to_me": only_to_me,
-            "email_upload_started": email_upload_started,
-            "email_upload_page_access": email_page_access,
-            "email_guest_created": email_guest_created,
-            "email_guest_created_receipt": email_receipt,
-            "email_guest_expired": email_guest_expired
+            "guest": {
+                "valid_only_one_time": one_time,
+                "can_only_send_to_me": only_to_me,
+                "email_upload_started": email_upload_started,
+                "email_upload_page_access": email_page_access,
+                "email_guest_created": email_guest_created,
+                "email_guest_created_receipt": email_receipt,
+                "email_guest_expired": email_guest_expired
+            },
+            "transfer": {
+                "add_me_to_recipients": False
+            }
         }
     })
     if verbose:

--- a/filesender/request_types.py
+++ b/filesender/request_types.py
@@ -67,6 +67,7 @@ Guest = TypedDict("Guest", {
     "from": str,
     "subject": NotRequired[str],
     "message": NotRequired[str],
-    "options": NotRequired[GuestAllOptions],
+    "options": NotRequired[GuestOptions],
+    "transfer_options": NotRequired[TransferOptions],
     "expires": NotRequired[int]
 })

--- a/filesender/request_types.py
+++ b/filesender/request_types.py
@@ -67,7 +67,7 @@ Guest = TypedDict("Guest", {
     "from": str,
     "subject": NotRequired[str],
     "message": NotRequired[str],
-    "options": NotRequired[GuestOptions],
-    "transfer_options": NotRequired[TransferOptions],
+    # See https://github.com/filesender/filesender/issues/1772
+    "options": NotRequired[GuestAllOptions],
     "expires": NotRequired[int]
 })

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2,8 +2,35 @@ from filesender.main import app
 from typer.testing import CliRunner
 import tempfile
 from os import remove
+import pytest
 
 runner = CliRunner()
+
+@pytest.mark.parametrize("guest_opts", [
+    ["--no-one-time"],
+    ["--no-only-to-me"],
+])
+def test_guest_params(base_url: str, username: str, apikey: str, recipient: str, delay: int, guest_opts: list[str]):
+    """
+    This tests configuring some guest options using the CLI
+    """
+    with tempfile.NamedTemporaryFile("wb", delete=False) as file:
+        # Make a 1 MB file
+        file.truncate(1024)
+        file.close()
+        result = runner.invoke(app, [
+            "--base-url", base_url,
+            "invite",
+            recipient,
+            "--username", username,
+            "--apikey", apikey,
+            "--delay", str(delay),
+            *guest_opts
+        ], catch_exceptions=False)
+        if result.exit_code != 0:
+            raise Exception(result.output)
+        remove(file.name)
+
 
 def test_large_upload(base_url: str, username: str, apikey: str, recipient: str, delay: int):
     """

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -7,7 +7,31 @@ import pytest
 
 from filesender.request_types import GuestOptions
 
-def test_round_trip(base_url, username, apikey, recipient):
+@pytest.mark.parametrize("guest_opts", [
+    {},
+    {"can_only_send_to_me": False}
+])
+def test_guest_creation(base_url: str, username: str, apikey: str, recipient: str, guest_opts: GuestOptions):
+    user_client = FileSenderClient(
+        base_url=base_url,
+        auth=UserAuth(
+            api_key=apikey,
+            username=username
+        )
+    )
+
+    # Invite the guest
+    guest = user_client.create_guest({
+        "recipient": recipient,
+        "from": username,
+        "options": {
+            "guest": guest_opts
+        }
+    })
+
+    assert len(guest["options"]) == len(guest_opts)
+
+def test_round_trip(base_url: str, username: str, apikey: str, recipient: str):
     """
     This tests uploading a 1MB file, with ensures that the chunking behaviour is correct,
     but also the multithreaded uploading

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -3,6 +3,9 @@ from filesender.api import FileSenderClient
 from filesender.auth import UserAuth, GuestAuth
 from pathlib import Path
 from random import randbytes
+import pytest
+
+from filesender.request_types import GuestOptions
 
 def test_round_trip(base_url, username, apikey, recipient):
     """
@@ -46,7 +49,11 @@ def test_round_trip(base_url, username, apikey, recipient):
         assert len(list(Path(download_dir).iterdir())) == 1
 
 
-def test_voucher_round_trip(base_url, username, apikey, recipient):
+@pytest.mark.parametrize("guest_opts", [
+    {},
+    {"can_only_send_to_me": False}
+])
+def test_voucher_round_trip(base_url: str, username: str, apikey: str, recipient: str, guest_opts: GuestOptions):
     """
     This tests uploading a 1GB file, with ensures that the chunking behaviour is correct,
     but also the multithreaded uploading
@@ -63,7 +70,8 @@ def test_voucher_round_trip(base_url, username, apikey, recipient):
     # Invite the guest
     guest = user_client.create_guest({
         "recipient": recipient,
-        "from": username
+        "from": username,
+        "options": guest_opts
     })
 
     guest_auth = GuestAuth(guest_token=guest["token"])


### PR DESCRIPTION
Closes #14 and helps with #9

* Allow configuring guest options in CLI
* Added `"add_me_to_recipients": False` as a default transfer option to work around https://github.com/filesender/filesender/issues/1773
* Fixed the `verbose` flag for the `invite` subcommand
* Added a number of guest voucher tests
* Fix for the rare case when you have used the same `requests.Session` previously such that it has the `Csrftoken` cookie set, but the `GuestAuth` isn't aware of it