### PR TITLE
Support Python 3.8+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: pip install .
       - uses: jakebailey/pyright-action@v2
         with:
           version: 1.1.367

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - uses: jakebailey/pyright-action@v2
+        with:
+          version: 1.1.367

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Coroutine, List, Optional, Tuple, AsyncIterator
+from typing import Any, Coroutine, List, Optional, Tuple, AsyncIterator, Set
 from bs4 import BeautifulSoup
 import filesender.response_types as response
 import filesender.request_types as request
@@ -258,7 +258,7 @@ class FileSenderClient:
             json=body
         ))
 
-    async def _files_from_token(self, token: str) -> set[int]:
+    async def _files_from_token(self, token: str) -> Set[int]:
         """
         Internal function that returns a list of file IDs for a given guest token
         """
@@ -269,7 +269,7 @@ class FileSenderClient:
                 "token": token
             }
         )
-        files: set[int] = set()
+        files: Set[int] = set()
         for file in BeautifulSoup(download_page.content, "html.parser").find_all(class_="file"):
             files.add(int(file.attrs["data-id"]))
         return files

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -222,7 +222,7 @@ class FileSenderClient:
                     self._upload_chunk(chunk=chunk, offset=offset, file_info=file_info)
                 )
         # Pause until all running tasks are finished
-        gather(*tasks)
+        await gather(*tasks)
 
     async def _upload_chunk(
         self,
@@ -294,7 +294,7 @@ class FileSenderClient:
             self.download_file(token=token, file_id=file, out_dir=out_dir)
             for file in await self._files_from_token(token)
         ]
-        gather(*tasks)
+        await gather(*tasks)
 
     async def download_file(
         self,
@@ -369,7 +369,7 @@ class FileSenderClient:
         # Upload each file in parallel
         # Note: update to TaskGroup once Python 3.10 is unsupported
         tasks = [self.upload_complete(file_info=file, path=files_by_name[file["name"]]) for file in transfer["files"]]
-        gather(*tasks)
+        await gather(*tasks)
 
         transfer = await self.update_transfer(
             transfer_id=transfer["id"], body={"complete": True}

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -10,6 +10,7 @@ from asyncio import Semaphore, gather
 import aiofiles
 from contextlib import contextmanager
 
+
 def url_without_scheme(url: str) -> str:
     """
     Returns the URL in the appropriate format for the signature calculation, namely:
@@ -18,6 +19,7 @@ def url_without_scheme(url: str) -> str:
     • With query parameters
     """
     return unquote(urlunparse(urlparse(url)._replace(scheme="")).lstrip("/"))
+
 
 @contextmanager
 def raise_status():
@@ -28,9 +30,14 @@ def raise_status():
     try:
         yield
     except HTTPStatusError as e:
-        raise Exception(f"Request failed with content {e.response.text} for request {e.request.method} {e.request.url}") from e
+        raise Exception(
+            f"Request failed with content {e.response.text} for request {e.request.method} {e.request.url}"
+        ) from e
     except RequestError as e:
-        raise Exception(f"Request failed for request {e.request.method} {e.request.url}") from e
+        raise Exception(
+            f"Request failed for request {e.request.method} {e.request.url}"
+        ) from e
+
 
 async def yield_chunks(path: Path, chunk_size: int) -> AsyncIterator[Tuple[bytes, int]]:
     """
@@ -47,10 +54,12 @@ async def yield_chunks(path: Path, chunk_size: int) -> AsyncIterator[Tuple[bytes
             yield chunk, offset
             offset += len(chunk)
 
+
 class FileSenderClient:
     """
     A client that can be used to programmatically interact with FileSender.
     """
+
     #: The base url of the file sender's API. For example https://filesender.aarnet.edu.au/rest.php
     base_url: str
     #: Size of upload chunks
@@ -70,12 +79,12 @@ class FileSenderClient:
         chunk_size: Optional[int] = None,
         auth: Auth = Auth(),
         concurrent_reads: Optional[int] = None,
-        concurrent_requests: Optional[int] = None
+        concurrent_requests: Optional[int] = None,
     ):
         """
         Args:
             base_url: The base URL for the FileSender instance you want to interact with.
-                This should just be a host name such as `https://filesender.aarnet.edu.au`, 
+                This should just be a host name such as `https://filesender.aarnet.edu.au`,
                 and should *not* include `/rest.php` or any other path element.
             chunk_size: The chunk size (in bytes) used for uploading, which is the amount of data that is sent to the server per request.
                 By default this is the maximum chunk size allowed by the server, but you might want to adjust this to reduce memory
@@ -97,8 +106,8 @@ class FileSenderClient:
         self.chunk_size = chunk_size
         # If we don't want a concurrency limit, we just use an infinitely large semaphore
         # See: https://github.com/python/typeshed/issues/12147
-        self._read_sem = Semaphore(concurrent_reads or float("inf")) # type: ignore
-        self._req_sem = Semaphore(concurrent_requests or float("inf")) # type: ignore
+        self._read_sem = Semaphore(concurrent_reads or float("inf"))  # type: ignore
+        self._req_sem = Semaphore(concurrent_requests or float("inf"))  # type: ignore
 
     async def prepare(self) -> None:
         """
@@ -109,7 +118,9 @@ class FileSenderClient:
         if self.chunk_size is None:
             self.chunk_size = info["upload_chunk_size"]
         elif self.chunk_size > info["upload_chunk_size"]:
-            raise Exception(f"--chunk-size can't be greater than the server's maximum supported chunk size. For this server, the maximum is {info['upload_chunk_size']}")
+            raise Exception(
+                f"--chunk-size can't be greater than the server's maximum supported chunk size. For this server, the maximum is {info['upload_chunk_size']}"
+            )
 
     async def _sign_send(self, request: Request) -> Any:
         """
@@ -136,11 +147,13 @@ class FileSenderClient:
         Returns:
             : See [`Transfer`][filesender.response_types.Transfer] (this is a different type from the input parameter).
         """
-        return await self._sign_send(self.http_client.build_request(
-            "POST",
-            f"{self.base_url}/transfer",
-            json=body,
-        ))
+        return await self._sign_send(
+            self.http_client.build_request(
+                "POST",
+                f"{self.base_url}/transfer",
+                json=body,
+            )
+        )
 
     async def update_transfer(
         self,
@@ -158,11 +171,13 @@ class FileSenderClient:
         Returns:
             : See [`Transfer`][filesender.response_types.Transfer]
         """
-        return await self._sign_send(self.http_client.build_request(
-            "PUT",
-            f"{self.base_url}/transfer/{transfer_id}",
-            json=body,
-        ))
+        return await self._sign_send(
+            self.http_client.build_request(
+                "PUT",
+                f"{self.base_url}/transfer/{transfer_id}",
+                json=body,
+            )
+        )
 
     async def update_file(
         self,
@@ -177,20 +192,16 @@ class FileSenderClient:
             file_info: Identifier obtained from the result of [`create_transfer`][filesender.FileSenderClient.create_transfer]
             body: See [`FileUpdate`][filesender.request_types.FileUpdate]
         """
-        await self._sign_send(self.http_client.build_request(
-            "PUT",
-            f"{self.base_url}/file/{file_info['id']}",
-            params={
-                "key": file_info["uid"]
-            },
-            json=body,
-        ))
+        await self._sign_send(
+            self.http_client.build_request(
+                "PUT",
+                f"{self.base_url}/file/{file_info['id']}",
+                params={"key": file_info["uid"]},
+                json=body,
+            )
+        )
 
-    async def upload_file(
-        self,
-        file_info: response.File,
-        path: Path
-    ) -> None:
+    async def upload_file(self, file_info: response.File, path: Path) -> None:
         """
         Uploads a file, with multiple chunks being uploaded in parallel
         Generally you should use [`upload_workflow`][filesender.FileSenderClient.upload_workflow] instead of this, which is much more user friendly.
@@ -207,11 +218,9 @@ class FileSenderClient:
         async for chunk, offset in yield_chunks(path, self.chunk_size):
             async with self._read_sem:
                 # However, the upload is not awaited, which allows them to run in parallel
-                tasks.append(self._upload_chunk(
-                    chunk=chunk,
-                    offset=offset,
-                    file_info=file_info
-                ))
+                tasks.append(
+                    self._upload_chunk(chunk=chunk, offset=offset, file_info=file_info)
+                )
         # Pause until all running tasks are finished
         gather(*tasks)
 
@@ -224,25 +233,22 @@ class FileSenderClient:
         """
         Internal function to upload a single chunk of data for a file
         """
-        return await self._sign_send(self.http_client.build_request(
-            "PUT",
-            f"{self.base_url}/file/{file_info['id']}/chunk/{offset}",
-            params={
-                "key": file_info["uid"]
-            },
-            content=chunk,
-            headers={
-                "Content-Type": 'application/octet-stream',
-                "X-Filesender-File-Size": str(file_info["size"]),
-                "X-Filesender-Chunk-Offset": str(offset),
-                "X-Filesender-Chunk-Size": str(len(chunk))
-            },
-        ))
+        return await self._sign_send(
+            self.http_client.build_request(
+                "PUT",
+                f"{self.base_url}/file/{file_info['id']}/chunk/{offset}",
+                params={"key": file_info["uid"]},
+                content=chunk,
+                headers={
+                    "Content-Type": "application/octet-stream",
+                    "X-Filesender-File-Size": str(file_info["size"]),
+                    "X-Filesender-Chunk-Offset": str(offset),
+                    "X-Filesender-Chunk-Size": str(len(chunk)),
+                },
+            )
+        )
 
-    async def create_guest(
-        self,
-        body: request.Guest
-    ) -> response.Guest:
+    async def create_guest(self, body: request.Guest) -> response.Guest:
         """
         Sends a voucher to a guest to invite them to send files
 
@@ -252,25 +258,21 @@ class FileSenderClient:
         Returns:
             : See [`Guest`][filesender.response_types.Guest]
         """
-        return await self._sign_send(self.http_client.build_request(
-            "POST",
-            f"{self.base_url}/guest",
-            json=body
-        ))
+        return await self._sign_send(
+            self.http_client.build_request("POST", f"{self.base_url}/guest", json=body)
+        )
 
     async def _files_from_token(self, token: str) -> Set[int]:
         """
         Internal function that returns a list of file IDs for a given guest token
         """
         download_page = await self.http_client.get(
-            "https://filesender.aarnet.edu.au",
-            params = {
-                "s": "download",
-                "token": token
-            }
+            "https://filesender.aarnet.edu.au", params={"s": "download", "token": token}
         )
         files: Set[int] = set()
-        for file in BeautifulSoup(download_page.content, "html.parser").find_all(class_="file"):
+        for file in BeautifulSoup(download_page.content, "html.parser").find_all(
+            class_="file"
+        ):
             files.add(int(file.attrs["data-id"]))
         return files
 
@@ -285,17 +287,14 @@ class FileSenderClient:
         Params:
             token: Obtained from the transfer email. The same as [`GuestAuth`][filesender.GuestAuth]'s `guest_token`.
             out_dir: The path to write the downloaded files.
-            key: 
+            key:
         """
         # Each file is downloaded in parallel
-        gather(
-
-                    self.download_file(
-                        token=token,
-                        file_id=file,
-                        out_dir=out_dir
-                    ) for file in await self._files_from_token(token)
-        )
+        tasks = [
+            self.download_file(token=token, file_id=file, out_dir=out_dir)
+            for file in await self._files_from_token(token)
+        ]
+        gather(*tasks)
 
     async def download_file(
         self,
@@ -303,7 +302,7 @@ class FileSenderClient:
         file_id: int,
         out_dir: Path,
         key: Optional[bytes] = None,
-        algorithm: Optional[str] = None
+        algorithm: Optional[str] = None,
     ) -> None:
         """
         Downloads a single file.
@@ -313,11 +312,12 @@ class FileSenderClient:
             file_id: A single file ID indicating the file to be downloaded.
             out_dir: The path to write the downloaded file.
         """
-        download_endpoint = urlunparse(urlparse(self.base_url)._replace(path="/download.php"))
-        async with self.http_client.stream("GET", download_endpoint, params={
-            "files_ids": file_id,
-            "token": token
-        }) as res:
+        download_endpoint = urlunparse(
+            urlparse(self.base_url)._replace(path="/download.php")
+        )
+        async with self.http_client.stream(
+            "GET", download_endpoint, params={"files_ids": file_id, "token": token}
+        ) as res:
             for content_param in res.headers["Content-Disposition"].split(";"):
                 if "filename" in content_param:
                     filename = content_param.split("=")[1].lstrip('"').rstrip('"')
@@ -329,9 +329,7 @@ class FileSenderClient:
                 async for chunk in res.aiter_raw(chunk_size=8192):
                     await fp.write(chunk)
 
-    async def get_server_info(
-        self
-    ) -> response.ServerInfo:
+    async def get_server_info(self) -> response.ServerInfo:
         """
         Returns all information known about the current FileSender server.
 
@@ -341,9 +339,7 @@ class FileSenderClient:
         return (await self.http_client.get(f"{self.base_url}/info")).json()
 
     async def upload_workflow(
-        self,
-        files: List[Path],
-        transfer_args: request.PartialTransfer = {}
+        self, files: List[Path], transfer_args: request.PartialTransfer = {}
     ) -> response.Transfer:
         """
         High level function for uploading one or more files
@@ -355,48 +351,35 @@ class FileSenderClient:
         Returns:
             : See [`Transfer`][filesender.response_types.Transfer]
         """
-        files_by_name = {
-            path.name: path for path in files
-        }
-        transfer = await self.create_transfer({
-            "files": [{
-                "name": file.name,
-                "size": file.stat().st_size
-            } for file in files],
-            "options": {
-                "email_download_complete": True,
-            },
-            **transfer_args
-        })
-        self.http_client.params = self.http_client.params.set("roundtriptoken", transfer["roundtriptoken"])
+        files_by_name = {path.name: path for path in files}
+        transfer = await self.create_transfer(
+            {
+                "files": [
+                    {"name": file.name, "size": file.stat().st_size} for file in files
+                ],
+                "options": {
+                    "email_download_complete": True,
+                },
+                **transfer_args,
+            }
+        )
+        self.http_client.params = self.http_client.params.set(
+            "roundtriptoken", transfer["roundtriptoken"]
+        )
         # Upload each file in parallel
         # Note: update to TaskGroup once Python 3.10 is unsupported
-        gather(
-            self.upload_complete(
-                file_info=file,
-                path=files_by_name[file["name"]]
-            ) for file in transfer["files"]
-        )
+        tasks = [self.upload_complete(file_info=file, path=files_by_name[file["name"]]) for file in transfer["files"]]
+        gather(*tasks)
 
         transfer = await self.update_transfer(
-            transfer_id=transfer["id"],
-            body={"complete": True}
+            transfer_id=transfer["id"], body={"complete": True}
         )
         return transfer
 
-    async def upload_complete(self,
-        file_info: response.File,
-        path: Path
-    ) -> None:
+    async def upload_complete(self, file_info: response.File, path: Path) -> None:
         """
         Uploads a file and marks the upload as complete.
         Generally you should use [`upload_workflow`][filesender.FileSenderClient.upload_workflow] instead of this, which is much more user friendly.
         """
-        await self.upload_file(
-            file_info=file_info,
-            path=path
-        )
-        await self.update_file(
-            file_info=file_info,
-            body={"complete": True}
-        )
+        await self.upload_file(file_info=file_info, path=path)
+        await self.update_file(file_info=file_info, body={"complete": True})

--- a/filesender/auth.py
+++ b/filesender/auth.py
@@ -5,7 +5,7 @@ import time
 from httpx import Request, QueryParams, AsyncClient
 from urllib.parse import urlparse, urlunparse, unquote
 from typing import Optional, TypeVar
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from collections.abc import Iterable
 import logging
 
@@ -93,7 +93,10 @@ class GuestAuth(Auth):
             }
         )
         soup = BeautifulSoup(res.content, 'html.parser')
-        self.security_token = soup.find("body").attrs["data-security-token"]
+        body = soup.find("body")
+        if not isinstance(body, Tag):
+            raise Exception("Invalid HTML document")
+        self.security_token = body.attrs["data-security-token"]
         self.csrf_token = res.cookies.get("csrfptoken")
         # We might already have the token, because we requested the server info earlier
         if self.csrf_token is None and "csrfptoken" in client.cookies:

--- a/filesender/benchmark.py
+++ b/filesender/benchmark.py
@@ -59,7 +59,7 @@ def make_tempfiles(size: int, n: int = 2, **kwargs: Any) -> Generator[list[Path]
         files = [stack.enter_context(make_tempfile(size=size, **kwargs)) for _ in range(n)]
         yield files
 
-async def upload_capture_mem(client_args: dict, upload_args: dict) -> BenchResult:
+async def upload_capture_mem(client_args: dict[str, Any], upload_args: dict[str, Any]) -> BenchResult:
     """
     Performs an upload, and returns the memory usage in doing so
     """
@@ -94,7 +94,7 @@ def benchmark(paths: list[Path], read_limit: Iterable[int | float], req_limit: I
     # We use multiprocessing so that each benchmark runs in a separate Python interpreter with a separate RSS
     # The spawn context ensures that no memory is shared with the controlling process
     with mp.get_context("spawn").Pool(processes=1) as pool:
-        args = [] 
+        args: list[tuple[Any, ...]] = [] 
         for concurrent_reads, concurrent_requests in zip(read_limit, req_limit):
             args.append(({
                     "base_url": base_url,

--- a/filesender/benchmark.py
+++ b/filesender/benchmark.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager, ExitStack
 from random import randbytes
 import tempfile
 from pathlib import Path
-from typing import Any, Generator, Iterable
+from typing import Any, Generator, Iterable, List, Tuple, Union
 from dataclasses import dataclass
 import multiprocessing as mp
 
@@ -40,7 +40,7 @@ def make_tempfile(size: int, **kwargs: Any) -> Generator[Path, Any, None]:
         path.unlink()
     
 @contextmanager
-def make_tempfiles(size: int, n: int = 2, **kwargs: Any) -> Generator[list[Path], Any, None]:
+def make_tempfiles(size: int, n: int = 2, **kwargs: Any) -> Generator[List[Path], Any, None]:
     """
     Makes `n` temporary files of size `size` and yields them as a list via context manager.
     
@@ -78,7 +78,7 @@ async def upload_capture_mem(client_args: dict[str, Any], upload_args: dict[str,
 def upload_capture_mem_sync(*args: Any) -> BenchResult:
     return asyncio.run(upload_capture_mem(*args))
 
-def benchmark(paths: list[Path], read_limit: Iterable[int | float], req_limit: Iterable[int | float], base_url: str, username: str, apikey: str, recipient: str) -> list[BenchResult]:
+def benchmark(paths: List[Path], read_limit: Iterable[Union[int, float]], req_limit: Iterable[Union[int, float]], base_url: str, username: str, apikey: str, recipient: str) -> List[BenchResult]:
     """
     Runs a test upload using a variety of semaphore settings, and return one result for each.
 
@@ -94,7 +94,7 @@ def benchmark(paths: list[Path], read_limit: Iterable[int | float], req_limit: I
     # We use multiprocessing so that each benchmark runs in a separate Python interpreter with a separate RSS
     # The spawn context ensures that no memory is shared with the controlling process
     with mp.get_context("spawn").Pool(processes=1) as pool:
-        args: list[tuple[Any, ...]] = [] 
+        args: List[Tuple[Any, ...]] = [] 
         for concurrent_reads, concurrent_requests in zip(read_limit, req_limit):
             args.append(({
                     "base_url": base_url,

--- a/filesender/benchmark.py
+++ b/filesender/benchmark.py
@@ -5,10 +5,10 @@ import resource
 import asyncio
 import time
 from contextlib import contextmanager, ExitStack
-from random import randbytes
+from secrets import token_bytes
 import tempfile
 from pathlib import Path
-from typing import Any, Generator, Iterable, List, Tuple, Union
+from typing import Any, Dict, Generator, Iterable, List, Tuple, Union
 from dataclasses import dataclass
 import multiprocessing as mp
 
@@ -34,7 +34,7 @@ def make_tempfile(size: int, **kwargs: Any) -> Generator[Path, Any, None]:
     """
     with tempfile.NamedTemporaryFile(mode="wb", delete=False, **kwargs) as file:
         path = Path(file.name)
-        file.write(randbytes(size))
+        file.write(token_bytes(size))
         file.close()
         yield Path(file.name)
         path.unlink()
@@ -59,7 +59,7 @@ def make_tempfiles(size: int, n: int = 2, **kwargs: Any) -> Generator[List[Path]
         files = [stack.enter_context(make_tempfile(size=size, **kwargs)) for _ in range(n)]
         yield files
 
-async def upload_capture_mem(client_args: dict[str, Any], upload_args: dict[str, Any]) -> BenchResult:
+async def upload_capture_mem(client_args: Dict[str, Any], upload_args: Dict[str, Any]) -> BenchResult:
     """
     Performs an upload, and returns the memory usage in doing so
     """

--- a/filesender/config.py
+++ b/filesender/config.py
@@ -1,17 +1,21 @@
 from configparser import ConfigParser
 from pathlib import Path
+from typing import TypedDict
 
 CONFIG_PATH = Path.home() / ".filesender" / "filesender.py.ini"
 
-def get_defaults() -> dict:
-    defaults = {}
+class Defaults(TypedDict, total=False):
+    base_url: str
+    username: str
+    apikey: str
+
+def get_defaults() -> Defaults:
+    defaults: Defaults = {}
     if CONFIG_PATH.exists():
         parser = ConfigParser()
         parser.read(CONFIG_PATH)
         if parser.has_option("system", "base_url"):
             defaults["base_url"] = parser.get("system", "base_url")
-        if parser.has_option("system", "default_transfer_days_valid"):
-            defaults["default_transfer_days_valid"] = parser.get("system", "default_transfer_days_valid")
         if parser.has_option("user", "username"):
             defaults["username"] = parser.get("user", "username")
         if parser.has_option("user", "apikey"):

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, List, Optional, Callable, Coroutine
+from typing import Any, List, Optional, Callable, Coroutine, Dict
 from typing_extensions import Annotated, ParamSpec, TypeVar
 from filesender.api import FileSenderClient
 from typer import Typer, Option, Argument, Context, Exit
@@ -29,7 +29,7 @@ Delay = Annotated[int, Option(help="Delay the signature timestamp by N seconds. 
 ConcurrentReads = Annotated[Optional[int], Option(help="The maximum number of file chunks that can be processed at a time. Reducing this number will decrease the memory usage of the application. None, the default value, sets no limit. See https://wehi-researchcomputing.github.io/FileSenderCli/benchmark for a detailed explanation of this parameter.")]
 ConcurrentReqs = Annotated[Optional[int], Option(help="The maximum number of API requests the client can be waiting for at a time. Reducing this number will decrease the memory usage of the application. None, the default value, sets no limit. See https://wehi-researchcomputing.github.io/FileSenderCli/benchmark for a detailed explanation of this parameter.")]
 
-context: dict[Any, Any] = {
+context: Dict[Any, Any] = {
     "default_map": get_defaults()
 }
 app = Typer(name="filesender", pretty_exceptions_enable=False)

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -28,7 +28,7 @@ Delay = Annotated[int, Option(help="Delay the signature timestamp by N seconds. 
 ConcurrentReads = Annotated[Optional[int], Option(help="The maximum number of file chunks that can be processed at a time. Reducing this number will decrease the memory usage of the application. None, the default value, sets no limit. See https://wehi-researchcomputing.github.io/FileSenderCli/benchmark for a detailed explanation of this parameter.")]
 ConcurrentReqs = Annotated[Optional[int], Option(help="The maximum number of API requests the client can be waiting for at a time. Reducing this number will decrease the memory usage of the application. None, the default value, sets no limit. See https://wehi-researchcomputing.github.io/FileSenderCli/benchmark for a detailed explanation of this parameter.")]
 
-context = {
+context: dict[Any, Any] = {
     "default_map": get_defaults()
 }
 app = Typer(name="filesender", pretty_exceptions_enable=False)

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -1,5 +1,6 @@
-from typing import Any, List, Optional, Callable, ParamSpec, TypeVar, Coroutine
-from typing_extensions import Annotated
+from __future__ import annotations
+from typing import Any, List, Optional, Callable, Coroutine
+from typing_extensions import Annotated, ParamSpec, TypeVar
 from filesender.api import FileSenderClient
 from typer import Typer, Option, Argument, Context, Exit
 from rich import print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "filesender-client"
 description = "FileSender Python CLI and API client"
 version = "1.2.1"
-readme = "README.rst"
+readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["one", "two"]
 license = {text = "BSD-3-Clause"}
@@ -21,8 +21,12 @@ dependencies = [
     "aiofiles",
     # See: https://github.com/encode/httpcore/pull/883
     "httpcore >= 1.0.3",
-    "cryptography"
+    "cryptography",
+    "typing_extensions"
 ]
+
+[tool.setuptools.packages.find]
+exclude = ["site"]
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "httpx",
     "aiofiles",
     # See: https://github.com/encode/httpcore/pull/883
-    "httpcore >= 1.0.3"
+    "httpcore >= 1.0.3",
+    "cryptography"
 ]
 
 [project.optional-dependencies]
@@ -41,3 +42,7 @@ dev = [
 
 [project.scripts]
 filesender = "filesender.main:app"
+
+[tool.pyright]
+typeCheckingMode = "strict"
+exclude = ["venv", "test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "filesender-client"
 description = "FileSender Python CLI and API client"
 version = "1.2.1"
 readme = "README.rst"
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 keywords = ["one", "two"]
 license = {text = "BSD-3-Clause"}
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["site"]
+exclude = ["site", "test"]
 
 [project.optional-dependencies]
 dev = [

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,6 +3,7 @@ from typer.testing import CliRunner
 import tempfile
 from os import remove
 import pytest
+from typing import List
 
 runner = CliRunner()
 
@@ -10,7 +11,7 @@ runner = CliRunner()
     ["--no-one-time"],
     ["--no-only-to-me"],
 ])
-def test_guest_params(base_url: str, username: str, apikey: str, recipient: str, delay: int, guest_opts: list[str]):
+def test_guest_params(base_url: str, username: str, apikey: str, recipient: str, delay: int, guest_opts: List[str]):
     """
     This tests configuring some guest options using the CLI
     """


### PR DESCRIPTION
Closes #21, closes #6

## Changes
* Add CI that installs the package and runs the `pyright` type checker on Python 3.8+
* Use older typing idioms like `List` instead of `list` to support Python 3.8
* Use `asyncio.gather` instead of `asyncio.TaskGroup`
* Use `secrets.token_bytes` instead of `random.randbytes`
* Various typing fixes to ensure that `pyright` is happy
* Improvements to the `pyproject.toml` to add missing libraries and fix some installation issues

## Benchmarks
Here are the time benchmarks for up to 4 concurrent threads. Oddly enough, with these changes I get much better performance.
### `main` branch
![image](https://github.com/WEHI-ResearchComputing/FileSenderCli/assets/5019367/b2cb5ea8-0b6f-442c-b1ae-9bd76cdf68f3)

### `py38` branch
![image](https://github.com/WEHI-ResearchComputing/FileSenderCli/assets/5019367/247f6dee-f8d1-45bd-b07f-5d630df464d6)

