### PR TITLE
Bump typer minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "typer>=0.9.0",
+    # --base-url is treated as an argument in 0.9.0-0.9.1
+    "typer>=0.9.2",
     "beautifulsoup4",
     "rich",
     "httpx",


### PR DESCRIPTION
This fixes the `No such option: --base-url` errors that it was possible to encounter before.