### PR TITLE
Logging

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Version 2.1.0
+
+### Added
+
+* A progress bar for file downloads
+
+### Changed
+
+* All terminal output is now through the `logging` module. You can use the new `--log-level` CLI parameter to configure the amount of info that is printed out.
+* Update the CLI default concurrency to 2 for chunks and 1 for files. This seems to be moderately performant without ever failing
+
 ## Version 2.0.0
 
 ### Added

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Optional, Tuple, AsyncIterator
+from typing import Any, Iterable, List, Optional, Tuple, AsyncIterator, Union
 from filesender.download import files_from_page, DownloadFile
 import filesender.response_types as response
 import filesender.request_types as request
@@ -366,7 +366,7 @@ class FileSenderClient:
         token: str,
         file_id: int,
         out_dir: Path,
-        file_size: int | float = float("inf"),
+        file_size: Union[int, float] = float("inf"),
         file_name: Optional[str] = None
     ) -> None:
         """

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -366,7 +366,7 @@ class FileSenderClient:
         token: str,
         file_id: int,
         out_dir: Path,
-        file_size: Union[int, float] = float("inf"),
+        file_size: Union[int, float, None] = None,
         file_name: Optional[str] = None
     ) -> None:
         """
@@ -376,7 +376,7 @@ class FileSenderClient:
             token: Obtained from the transfer email. The same as [`GuestAuth`][filesender.GuestAuth]'s `guest_token`.
             file_id: A single file ID indicating the file to be downloaded.
             out_dir: The path to write the downloaded file.
-            file_size: The file size in bytes, optionally
+            file_size: The file size in bytes, optionally.
             file_name: The file name of the file being downloaded. This will impact the name by which it's saved.
         """
         download_endpoint = urlunparse(
@@ -394,9 +394,11 @@ class FileSenderClient:
                 else:
                     raise Exception("No filename found")
 
+            file_path = out_dir / file_name
+            file_path.parent.mkdir(parents=True, exist_ok=True)
             chunk_size = 8192
             chunk_size_mb = chunk_size / 1024 / 1024
-            with tqdm(desc=file_name, unit="MB", total=int(file_size / 1024 / 1024)) as progress:
+            with tqdm(desc=file_name, unit="MB", total=None if file_size is None else int(file_size / 1024 / 1024)) as progress:
                 async with aiofiles.open(out_dir / file_name, "wb") as fp:
                     # We can't add the total here, because we don't know it: 
                     # https://github.com/filesender/filesender/issues/1555

--- a/filesender/api.py
+++ b/filesender/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Optional, Tuple, AsyncIterator, Set
+from typing import Any, Iterable, List, Optional, Tuple, AsyncIterator
 from filesender.download import files_from_page, DownloadFile
 import filesender.response_types as response
 import filesender.request_types as request
@@ -172,9 +172,10 @@ class FileSenderClient:
     @staticmethod
     def on_retry(state: RetryCallState) -> None:
         message = str(state.outcome)
-        if state.outcome is not None and state.outcome.failed:
+        if state.outcome is not None:
             e = state.outcome.exception()
-            message = exception_to_message(e)
+            if e is not None:
+                message = exception_to_message(e)
 
         logger.warn(f"Attempt {state.attempt_number}. {message}")
 

--- a/filesender/download.py
+++ b/filesender/download.py
@@ -1,0 +1,50 @@
+from typing import Iterable, TypedDict
+
+from bs4 import BeautifulSoup
+
+
+class DownloadFile(TypedDict):
+    client_entropy: str
+    encrypted: str
+    encrypted_size: int
+    fileaead: str
+    fileiv: str
+    id: int
+    key_salt: str
+    key_version: int
+    mime: str
+    #: filename
+    name: str
+    password_encoding: str
+    password_hash_iterations: int
+    password_version: int
+    size: int
+    transferid: int
+
+def files_from_page(content: bytes) -> Iterable[DownloadFile]:
+    """
+    Yields dictionaries describing the files listed on a FileSender web page
+
+    Params:
+        content: The HTML content of the FileSender download page 
+    """
+    for file in BeautifulSoup(content, "html.parser").find_all(
+        class_="file"
+    ):
+        yield {
+            "client_entropy": file.attrs[f"data-client-entropy"],
+            "encrypted": file.attrs["data-encrypted"],
+            "encrypted_size": int(file.attrs["data-encrypted-size"]),
+            "fileaead": file.attrs["data-fileaead"],
+            "fileiv": file.attrs["data-fileiv"],
+            "id": int(file.attrs["data-id"]),
+            "key_salt": file.attrs["data-key-salt"],
+            "key_version": int(file.attrs["data-key-version"]),
+            "mime": file.attrs["data-mime"],
+            "name": file.attrs["data-name"],
+            "password_encoding": file.attrs["data-password-encoding"],
+            "password_hash_iterations": int(file.attrs["data-password-hash-iterations"]),
+            "password_version": int(file.attrs["data-password-version"]),
+            "size": int(file.attrs["data-size"]),
+            "transferid": int(file.attrs["data-transferid"]),
+        }

--- a/filesender/log.py
+++ b/filesender/log.py
@@ -1,3 +1,4 @@
+from typing import Union
 from click import ParamType, Context, Parameter
 from enum import Enum
 
@@ -13,7 +14,7 @@ class LogLevel(Enum):
 class LogParam(ParamType):
     name = "LogParam"
 
-    def convert(self, value: int | str, param: Parameter | None, ctx: Context | None) -> int:
+    def convert(self, value: Union[int, str], param: Union[Parameter, None], ctx: Union[Context, None]) -> int:
         if isinstance(value, int):
             return value
 

--- a/filesender/log.py
+++ b/filesender/log.py
@@ -24,6 +24,6 @@ class LogParam(ParamType):
 
         return LogLevel[value].value
 
-    def get_metavar(self, param: Parameter) -> str | None:
+    def get_metavar(self, param: Parameter) -> Union[str, None]:
         # Print out the choices
         return "|".join(LogLevel._member_map_)

--- a/filesender/log.py
+++ b/filesender/log.py
@@ -1,15 +1,32 @@
 from typing import Union
 from click import ParamType, Context, Parameter
 from enum import Enum
+import logging
 
 class LogLevel(Enum):
     NOTSET = 0
     DEBUG = 10
+    #: Used for verbose logging that the average user wouldn't want
     VERBOSE = 15
     INFO = 20
+    #: Used for basic feedback that a CLI user would expect
+    FEEDBACK = 25
     WARNING = 30
     ERROR = 40
     CRITICAL = 50
+
+    def configure_label(self):
+        """
+        Configures the logging module to understand this log level
+        """
+        logging.addLevelName(self.value, self.name)
+
+def configure_extra_levels():
+    """
+    Configures the logging module to understand the additional log levels
+    """
+    for level in (LogLevel.VERBOSE, LogLevel.FEEDBACK):
+        level.configure_label()
 
 class LogParam(ParamType):
     name = "LogParam"

--- a/filesender/log.py
+++ b/filesender/log.py
@@ -1,0 +1,28 @@
+from click import ParamType, Context, Parameter
+from enum import Enum
+
+class LogLevel(Enum):
+    NOTSET = 0
+    DEBUG = 10
+    VERBOSE = 15
+    INFO = 20
+    WARNING = 30
+    ERROR = 40
+    CRITICAL = 50
+
+class LogParam(ParamType):
+    name = "LogParam"
+
+    def convert(self, value: int | str, param: Parameter | None, ctx: Context | None) -> int:
+        if isinstance(value, int):
+            return value
+
+        # Convert string representation to int
+        if not hasattr(LogLevel, value):
+            self.fail(f"{value!r} is not a valid log level", param, ctx)
+
+        return LogLevel[value].value
+
+    def get_metavar(self, param: Parameter) -> str | None:
+        # Print out the choices
+        return "|".join(LogLevel._member_map_)

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -60,8 +60,12 @@ def common_args(
         "base_url": base_url
     }
     logging.basicConfig(
-        level=log_level, format= "%(message)s", datefmt="[%X]", handlers=[RichHandler()]
+        level=log_level,
+        format= "%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler()]
     )
+    logging.addLevelName(LogLevel.VERBOSE.value, 'VERBOSE')
 
 
 @app.command(context_settings=context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "filesender-client"
 description = "FileSender Python CLI and API client"
-version = "2.0.0"
+version = "2.1.0"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["one", "two"]

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -6,6 +6,11 @@ import pytest
 from filesender.request_types import GuestOptions
 from filesender.benchmark import make_tempfile, make_tempfiles, benchmark
 
+def count_files_recursively(path: Path) -> int:
+    """
+    Returns a recursive count of the number of files within a directory. Subdirectories are not counted.
+    """
+    return sum([1 if child.is_file() else 0 for child in path.rglob("*")])
 
 @pytest.mark.asyncio
 async def test_round_trip(base_url: str, username: str, apikey: str, recipient: str):
@@ -34,7 +39,7 @@ async def test_round_trip(base_url: str, username: str, apikey: str, recipient: 
             file_id=transfer["files"][0]["id"],
             out_dir=Path(download_dir),
         )
-        assert len(list(Path(download_dir).iterdir())) == 1
+        assert count_files_recursively(Path(download_dir)) == 1
 
     
 @pytest.mark.asyncio
@@ -62,7 +67,7 @@ async def test_round_trip_dir(base_url: str, username: str, apikey: str, recipie
             token=transfer["recipients"][0]["token"],
             out_dir=Path(download_dir),
         )
-        assert len(list(Path(download_dir).iterdir())) == 2
+        assert count_files_recursively(Path(download_dir)) == 2
 
 
 @pytest.mark.asyncio
@@ -113,7 +118,7 @@ async def test_voucher_round_trip(
             file_id=transfer["files"][0]["id"],
             out_dir=Path(download_dir),
         )
-        assert len(list(Path(download_dir).iterdir())) == 1
+        assert count_files_recursively(Path(download_dir)) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Changes:
* Use `logging` instead of print statements throughout
* Add a `--log-level` CLI parameter for controlling verbosity
* Better logging when a request is retried
* Update the CLI default concurrency to 2 for chunks and 1 for files. This seems to be moderately performant without ever failing
* Scrape additional file metadata during download
* Added a progress bar for file downloads

TODOs:
* [x] Update changelog
* [x] Run tests