### PR TITLE
Stop supporting Python 3.8, add Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-Requires `Python>=3.8`
+Requires `Python>=3.9`
 
 ```bash
 pip install filesender-client

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Base URL was not being set correctly for download operations [[#29]](https://github.com/WEHI-ResearchComputing/FileSenderCli/pull/29).
+* Drop support for Python 3.8 as it is now end-of-life, and add support for Python 3.13 [[#31]](https://github.com/WEHI-ResearchComputing/FileSenderCli/pull/31)
 
 ## Version 2.1.0
 

--- a/filesender/auth.py
+++ b/filesender/auth.py
@@ -104,7 +104,7 @@ class GuestAuth(Auth):
                 if cookie.name.lower() == "csrfptoken":
                     self.csrf_token = cookie.value
         if self.csrf_token is None:
-            logger.warn("No CSRF token could be found!")
+            logger.warning("No CSRF token could be found!")
 
     def sign(self, request: SignType, client: AsyncClient) -> SignType:
         request.url = request.url.copy_add_param("vid", self.guest_token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "filesender-client"
 description = "FileSender Python CLI and API client"
 version = "2.1.1"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Stop supporting Python 3.8, add Python 3.13.

See: https://devguide.python.org/versions/.