### PR TITLE
add --aup-check

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* `--aup-checked` flag for the `upload`, `upload-voucher`, and `invite` commands. This is required when the FileSender instance has `aup_enabled=true` [[#679]](https://github.com/filesender/filesender/issues/679)
+
 ## Version 2.1.2
 
 ### Fixed

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -9,6 +9,7 @@ from rich.pretty import pretty_repr
 from pathlib import Path
 from filesender.auth import Auth, UserAuth, GuestAuth
 from filesender.config import get_defaults
+import filesender.request_types as request
 from functools import wraps
 from asyncio import run
 from importlib.metadata import version
@@ -65,6 +66,12 @@ UploadFiles = Annotated[
         resolve_path=True,
         exists=True,
         help="Files and/or directories to upload",
+    ),
+]
+AupChecked = Annotated[
+    bool,
+    Option(
+        help="Signal that the Acceptable Use Policy has been accepted. Required when the FileSender instance has aup_enabled=true.",
     ),
 ]
 
@@ -158,6 +165,7 @@ def invite(
         bool, Option(help="If true, send you an email when the voucher expires.")
     ] = False,
     delay: Delay = 0,
+    aup_checked: AupChecked = False,
 ):
     """
     Invites a user to send files to you
@@ -166,26 +174,25 @@ def invite(
         auth=UserAuth(api_key=apikey, username=username, delay=delay),
         base_url=context.obj["base_url"],
     )
-    result: Guest = run(
-        client.create_guest(
-            {
-                "from": username,
-                "recipient": recipient,
-                "options": {
-                    "guest": {
-                        "valid_only_one_time": one_time,
-                        "can_only_send_to_me": only_to_me,
-                        "email_upload_started": email_upload_started,
-                        "email_upload_page_access": email_page_access,
-                        "email_guest_created": email_guest_created,
-                        "email_guest_created_receipt": email_receipt,
-                        "email_guest_expired": email_guest_expired,
-                    },
-                    "transfer": {"add_me_to_recipients": False},
-                },
-            }
-        )
-    )
+    guest_body: request.Guest = {
+        "from": username,
+        "recipient": recipient,
+        "options": {
+            "guest": {
+                "valid_only_one_time": one_time,
+                "can_only_send_to_me": only_to_me,
+                "email_upload_started": email_upload_started,
+                "email_upload_page_access": email_page_access,
+                "email_guest_created": email_guest_created,
+                "email_guest_created_receipt": email_receipt,
+                "email_guest_expired": email_guest_expired,
+            },
+            "transfer": {"add_me_to_recipients": False},
+        },
+    }
+    if aup_checked:
+        guest_body["aup_checked"] = True
+    result: Guest = run(client.create_guest(guest_body))
     logger.log(LogLevel.VERBOSE.value, pretty_repr(result))
     logger.log(LogLevel.FEEDBACK.value, "Invitation successfully sent")
 
@@ -205,6 +212,7 @@ async def upload_voucher(
     concurrent_files: ConcurrentFiles = 1,
     concurrent_chunks: ConcurrentChunks = 2,
     chunk_size: ChunkSize = None,
+    aup_checked: AupChecked = False,
 ):
     """
     Uploads files to a voucher that you have been invited to
@@ -219,9 +227,10 @@ async def upload_voucher(
     )
     await auth.prepare(client.http_client)
     await client.prepare()
-    result: Transfer = await client.upload_workflow(
-        files, {"from": email, "recipients": []}
-    )
+    transfer_args: request.PartialTransfer = {"from": email, "recipients": []}
+    if aup_checked:
+        transfer_args["aup_checked"] = True
+    result: Transfer = await client.upload_workflow(files, transfer_args)
     logger.log(LogLevel.VERBOSE.value, pretty_repr(result))
     logger.log(LogLevel.FEEDBACK.value, "Upload completed successfully")
 
@@ -243,6 +252,7 @@ async def upload(
     concurrent_chunks: ConcurrentChunks = 2,
     chunk_size: ChunkSize = None,
     delay: Delay = 0,
+    aup_checked: AupChecked = False,
 ):
     """
     Sends files to an email of choice
@@ -255,9 +265,13 @@ async def upload(
         concurrent_chunks=concurrent_chunks,
     )
     await client.prepare()
-    result: Transfer = await client.upload_workflow(
-        files, {"recipients": recipients, "from": username}
-    )
+    transfer_args: request.PartialTransfer = {
+        "recipients": recipients,
+        "from": username,
+    }
+    if aup_checked:
+        transfer_args["aup_checked"] = True
+    result: Transfer = await client.upload_workflow(files, transfer_args)
     logger.log(LogLevel.VERBOSE.value, pretty_repr(result))
     logger.log(LogLevel.FEEDBACK.value, "Upload completed successfully")
 

--- a/filesender/main.py
+++ b/filesender/main.py
@@ -268,6 +268,11 @@ async def upload(
     transfer_args: request.PartialTransfer = {
         "recipients": recipients,
         "from": username,
+        "options": {
+            "get_a_link": False,
+            "add_me_to_recipients": True,
+            "email_download_complete": True,
+        },
     }
     if aup_checked:
         transfer_args["aup_checked"] = True

--- a/filesender/request_types.py
+++ b/filesender/request_types.py
@@ -41,6 +41,8 @@ PartialTransfer = TypedDict(
         "recipients": NotRequired[List[str]],
         # We need to use the expression syntax for TypedDict because `from` is a Python keyword
         "from": NotRequired[str],
+        # Required when the FileSender instance has aup_enabled=true
+        "aup_checked": NotRequired[bool],
     },
 )
 
@@ -85,5 +87,7 @@ Guest = TypedDict(
         # See https://github.com/filesender/filesender/issues/1772
         "options": NotRequired[GuestAllOptions],
         "expires": NotRequired[int],
+        # Required when the FileSender instance has aup_enabled=true
+        "aup_checked": NotRequired[bool],
     },
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "filesender-client"
 description = "FileSender Python CLI and API client"
-version = "2.1.2"
+version = "2.2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "BSD-3-Clause"}

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -199,3 +199,48 @@ async def test_client_download_url():
     mock_http_client.get.assert_called_once_with(
         "http://localhost:8080", params=dict(s="download", token=token)
     )
+
+
+@pytest.mark.asyncio
+async def test_client_transfer_create_aup_checked():
+    """
+    Tests that the transfer creation request body includes `aup_checked` when set.
+    This is required when the FileSender instance has aup_enabled=true
+    (see https://github.com/filesender/filesender/issues/679)
+    """
+    mock_http_client = MagicMock()
+    client = FileSenderClient(base_url="http://localhost:8080")
+    client.http_client = mock_http_client
+    try:
+        await client.create_transfer(
+            {
+                "files": [{"name": "file.txt", "size": 1}],
+                "aup_checked": True,
+            }
+        )
+    except Exception:
+        pass
+    json_body = mock_http_client.build_request.call_args.kwargs["json"]
+    assert json_body["aup_checked"] is True
+
+
+@pytest.mark.asyncio
+async def test_client_guest_create_aup_checked():
+    """
+    Tests that the guest creation request body includes `aup_checked` when set
+    """
+    mock_http_client = MagicMock()
+    client = FileSenderClient(base_url="http://localhost:8080")
+    client.http_client = mock_http_client
+    try:
+        await client.create_guest(
+            {
+                "recipient": "recipient@example.com",
+                "from": "sender@example.com",
+                "aup_checked": True,
+            }
+        )
+    except Exception:
+        pass
+    json_body = mock_http_client.build_request.call_args.kwargs["json"]
+    assert json_body["aup_checked"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -778,7 +778,7 @@ wheels = [
 
 [[package]]
 name = "filesender-client"
-version = "2.1.2"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
* `--aup-checked` flag for the `upload`, `upload-voucher`, and `invite` commands. This is required when the FileSender instance has `aup_enabled=true` [[#679]](https://github.com/filesender/filesender/issues/679)